### PR TITLE
Add support for HTTPS and fix argument passing

### DIFF
--- a/lib/jsonrpc-connector.js
+++ b/lib/jsonrpc-connector.js
@@ -70,8 +70,8 @@ JsonRpcConnector.prototype.mapOperation = function (op) {
             }   
             err = res && res.error;
             cb && cb(err, res && res.result);
-        }); 
-    }   
+        });
+    }
     return fn;
 }
 

--- a/lib/jsonrpc-connector.js
+++ b/lib/jsonrpc-connector.js
@@ -67,7 +67,7 @@ JsonRpcConnector.prototype.mapOperation = function (op) {
             if(err) {
                 cb && cb(err);
                 return;
-            }   
+            }
             err = res && res.error;
             cb && cb(err, res && res.result);
         });

--- a/lib/jsonrpc-connector.js
+++ b/lib/jsonrpc-connector.js
@@ -47,7 +47,11 @@ function JsonRpcConnector(options) {
     this.options = options;
 
     if (options.operations) {
-        this.client = jayson.client.http(options);
+        if (options.protocol == "http:") {
+            this.client = jayson.client.http(options);
+        } else if (options.protocol == "https:") {
+            this.client = jayson.client.https(options);
+        }
     }
 }
 
@@ -59,15 +63,15 @@ JsonRpcConnector.prototype.mapOperation = function (op) {
         if (args.length > 0 && typeof args[args.length - 1] === 'function') {
             cb = args.pop();
         }
-        client.request(op, args, function (err, res) {
+        client.request(op, args[0], function (err, res) {
             if(err) {
                 cb && cb(err);
                 return;
-            }
+            }   
             err = res && res.error;
             cb && cb(err, res && res.result);
-        });
-    }
+        }); 
+    }   
     return fn;
 }
 


### PR DESCRIPTION
We ran into a problem when trying to use a JSON RPC datasource which used HTTPS for communication. Jayson supports it, but this module did not. This pull requests contains the code we used to add support for HTTPS. We also made modifications so that we could pass arguments from the datasource config to Jayson such as "rejectUnauthorized".
